### PR TITLE
Fix finalize panic

### DIFF
--- a/evm_loader/program/Cargo.toml
+++ b/evm_loader/program/Cargo.toml
@@ -14,15 +14,14 @@ exclude = ["js/**"]
 [features]
 no-entrypoint = []
 custom-heap = []
-program = ["custom-heap", "solana-sdk/program", "spl-token/no-entrypoint"]
-default = ["custom-heap", "solana-sdk/program", "spl-token/default"]
+program = ["custom-heap", "solana-sdk/program"]
+default = ["custom-heap", "solana-sdk/program"]
 
 [dependencies]
 num-derive = "0.3"
 num-traits = "0.2"
 remove_dir_all = "=0.5.0"
-solana-sdk = { default-features = false, optional = true }
-spl-token = { path = "../../token/program", default-features = false, optional = true }
+solana-sdk = { version = "1.3.17", default-features = false, optional = true }
 thiserror = "1.0"
 arrayref = "0.3.6"
 num_enum = "0.5.1"

--- a/evm_loader/program/Cargo.toml
+++ b/evm_loader/program/Cargo.toml
@@ -13,14 +13,15 @@ exclude = ["js/**"]
 
 [features]
 no-entrypoint = []
-program = ["solana-sdk/program", "spl-token/program", "spl-token/no-entrypoint"]
-default = ["solana-sdk/default", "spl-token/default"]
+custom-heap = []
+program = ["custom-heap", "solana-sdk/program", "spl-token/no-entrypoint"]
+default = ["custom-heap", "solana-sdk/program", "spl-token/default"]
 
 [dependencies]
 num-derive = "0.3"
 num-traits = "0.2"
 remove_dir_all = "=0.5.0"
-solana-sdk = { path = "/root/solana/sdk", default-features = false, optional = true }
+solana-sdk = { default-features = false, optional = true }
 spl-token = { path = "../../token/program", default-features = false, optional = true }
 thiserror = "1.0"
 arrayref = "0.3.6"

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -138,20 +138,19 @@ fn do_finalize<'a>(program_id: &Pubkey, accounts: &'a [AccountInfo<'a>], program
 
     info!("Execute transact_create");
 
-    let code_data = program_info.data.borrow();
-    let (_unused, rest) = code_data.split_at(1);
-    let (code_len, rest) = rest.split_at(8);
-    let code_len = code_len
-        .try_into()
-        .ok()
-        .map(u64::from_le_bytes)
-        .unwrap();
-    let (code, _rest) = rest.split_at(code_len as usize);
+    let code_data = {
+        let data = program_info.data.borrow();
+        let (_unused, rest) = data.split_at(1);
+        let (code_len, rest) = rest.split_at(8);
+        let code_len = code_len.try_into().ok().map(u64::from_le_bytes).unwrap();
+        let (code, _rest) = rest.split_at(code_len as usize);
+        code.to_vec()
+    };
 
     let exit_reason = executor.transact_create2(
             solidity_address(&accounts[1].key),
             U256::zero(),
-            code.to_vec(),
+            code_data,
             program_info.key.to_bytes().into(), usize::max_value()
         );
     info!("  create2 done");

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -134,6 +134,8 @@ fn do_execute<'a>(
     let config = evm::Config::istanbul();
     let mut executor = StackExecutor::new(&backend, usize::max_value(), &config);
     info!("Executor initialized");
+    info!(&("   caller: ".to_owned() + &backend.get_address_by_index(1).to_string()));
+    info!(&(" contract: ".to_owned() + &backend.get_address_by_index(0).to_string()));
 
     let (exit_reason, result) = executor.transact_call(
             backend.get_address_by_index(1),

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -8,12 +8,13 @@ use arrayref::{array_ref, array_refs, array_mut_ref, mut_array_refs};
 use std::convert::TryInto;
 use solana_sdk::{
     account_info::{next_account_info, AccountInfo},
-    entrypoint, entrypoint::ProgramResult,
+    entrypoint, entrypoint::{ProgramResult, HEAP_START_ADDRESS},
     program_error::{ProgramError, PrintProgramError}, pubkey::Pubkey,
     program_utils::{limited_deserialize},
     loader_instruction::LoaderInstruction,
     info,
 };
+use std::{alloc::Layout, mem::size_of, ptr::null_mut, usize};
 
 use crate::hamt::Hamt;
 use crate::solana_backend::{
@@ -28,16 +29,56 @@ use evm::{
 use primitive_types::{H160, H256, U256};
 use std::collections::BTreeMap;
 
-fn unpack_loader_instruction(data: &[u8]) -> LoaderInstruction {
-    LoaderInstruction::Finalize
+
+const HEAP_LENGTH: usize = 1024*1024;
+
+/// Developers can implement their own heap by defining their own
+/// `#[global_allocator]`.  The following implements a dummy for test purposes
+/// but can be flushed out with whatever the developer sees fit.
+struct BumpAllocator;
+
+#[cfg(target_arch = "bpf")]
+#[global_allocator]
+static mut A: BumpAllocator = BumpAllocator;
+
+impl BumpAllocator {
+    #[inline]
+    fn occupied() -> usize {
+        const POS_PTR: *mut usize = HEAP_START_ADDRESS as *mut usize;
+        const TOP_ADDRESS: usize = HEAP_START_ADDRESS + HEAP_LENGTH;
+        const BOTTOM_ADDRESS: usize = HEAP_START_ADDRESS + size_of::<*mut u8>();
+
+        let mut pos = unsafe{*POS_PTR};
+        if pos == 0 {0} else {TOP_ADDRESS-pos}
+    }
 }
 
-//fn pubkey_to_address(key: &Pubkey) -> H160 {
-//    H256::from_slice(key.as_ref()).into()
-//}
+unsafe impl std::alloc::GlobalAlloc for BumpAllocator {
+    #[inline]
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        const POS_PTR: *mut usize = HEAP_START_ADDRESS as *mut usize;
+        const TOP_ADDRESS: usize = HEAP_START_ADDRESS + HEAP_LENGTH;
+        const BOTTOM_ADDRESS: usize = HEAP_START_ADDRESS + size_of::<*mut u8>();
 
+        let mut pos = *POS_PTR;
+        if pos == 0 {
+            // First time, set starting position
+            pos = TOP_ADDRESS;
+        }
+        pos = pos.saturating_sub(layout.size());
+        pos &= !(layout.align().saturating_sub(1));
+        if pos < BOTTOM_ADDRESS {
+            return null_mut();
+        }
 
-
+        *POS_PTR = pos;
+        pos as *mut u8
+    }
+    #[inline]
+    unsafe fn dealloc(&self, _: *mut u8, layout: Layout) {
+        // I'm a bump allocator, I don't free
+    }
+}
 
 entrypoint!(process_instruction);
 fn process_instruction<'a>(
@@ -52,24 +93,26 @@ fn process_instruction<'a>(
 
     let account_type = {program_info.data.borrow()[0]};
 
-    if account_type == 0 {
+    let result = if account_type == 0 {
         let instruction: LoaderInstruction = limited_deserialize(instruction_data)
             .map_err(|_| ProgramError::InvalidInstructionData)?;
 
         match instruction {
             LoaderInstruction::Write {offset, bytes} => {
-                return do_write(program_info, offset, &bytes);
+                do_write(program_info, offset, &bytes)
             },
             LoaderInstruction::Finalize => {
                 info!("FinalizeInstruction");
-                return do_finalize(program_id, accounts, program_info);
+                do_finalize(program_id, accounts, program_info)
             },
         }
     } else {
         info!("Execute");
-        return do_execute(program_id, accounts, instruction_data);
-    }
-    Ok(())
+        do_execute(program_id, accounts, instruction_data)
+    };
+
+    info!(&("Total memory occupied: ".to_owned() + &BumpAllocator::occupied().to_string()));
+    result
 }
 
 fn do_write(program_info: &AccountInfo, offset: u32, bytes: &Vec<u8>) -> ProgramResult {
@@ -93,7 +136,7 @@ fn do_finalize<'a>(program_id: &Pubkey, accounts: &'a [AccountInfo<'a>], program
     let mut executor = StackExecutor::new(&backend, usize::max_value(), &config);
     info!("  executor initialized");
 
-    //trace!("Execute transact_create");
+    info!("Execute transact_create");
 
     let code_data = program_info.data.borrow();
     let (_unused, rest) = code_data.split_at(1);

--- a/evm_loader/program/src/lib.rs
+++ b/evm_loader/program/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs)]
-#![forbid(unsafe_code)]
+//#![forbid(unsafe_code)]
 
 //! An ERC20-like Token program for the Solana blockchain
 

--- a/evm_loader/program/src/solana_backend.rs
+++ b/evm_loader/program/src/solana_backend.rs
@@ -23,7 +23,6 @@ use crate::account_data::AccountData;
 use solana_sdk::program::invoke;
 use solana_sdk::program::invoke_signed;
 use std::convert::TryInto;
-use std::str::FromStr;
 
 fn keccak256_digest(data: &[u8]) -> H256 {
     H256::from_slice(Keccak256::digest(&data).as_slice())

--- a/evm_loader/test.py
+++ b/evm_loader/test.py
@@ -39,7 +39,7 @@ class EvmLoaderTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.acc = Account(b'\xdc~\x1c\xc0\x1a\x97\x80\xc2\xcd\xdfn\xdb\x05.\xf8\x90N\xde\xf5\x042\xe2\xd8\x10xO%/\xe7\x89\xc0<')
-        print('Account:', cls.acc.public_key())
+        print('Account:', cls.acc.public_key(), bytes(cls.acc.public_key()).hex())
         print('Private:', cls.acc.secret_key())
         balance = http_client.get_balance(cls.acc.public_key())['result']['value']
         if balance == 0:
@@ -55,6 +55,15 @@ class EvmLoaderTests(unittest.TestCase):
             TransactionInstruction(program_id=evm_loader, data=data, keys=[
                 AccountMeta(pubkey=owner_contract, is_signer=False, is_writable=True),
                 AccountMeta(pubkey=self.acc.public_key(), is_signer=True, is_writable=False),
+            ]))
+        result = http_client.send_transaction(trx, self.acc)
+
+    def test_call_changeOwner(self):
+        data = bytearray.fromhex("a6f9dae10000000000000000000000005b38da6a701c568545dcfcb03fcb875f56beddc4")
+        trx = Transaction().add(
+            TransactionInstruction(program_id=evm_loader, data=data, keys=[
+                AccountMeta(pubkey=owner_contract, is_signer=False, is_writable=True),
+                AccountMeta(pubkey="6ghLBF2LZAooDnmUMVm8tdNK6jhcAQhtbQiC7TgVnQ2r", is_signer=False, is_writable=False),
             ]))
         result = http_client.send_transaction(trx, self.acc)
 

--- a/evm_loader/test.py
+++ b/evm_loader/test.py
@@ -3,13 +3,20 @@ from solana.account import Account
 from solana.transaction import AccountMeta, TransactionInstruction, Transaction
 import unittest
 import time
+import os
 
 http_client = Client("http://localhost:8899")
-evm_loader = "7Cdv9VeQEbBmXvJZaE4vmGkyobr1zUAJ8yu8urKFxpBM"
-owner_contract = "GoXMtBXLRLU3mQsfKtvTD2bWqmkfvSZmhcaTdCyC6vVk"
+evm_loader = os.environ.get("EVM_LOADER")  #"CLBfz3DZK4VBYAu6pCgDrQkNwLsQphT9tg41h6TQZAh3"
+owner_contract = os.environ.get("CONTRACT")  #"HegAG2D9DwRaSiRPb6SaDrmaMYFq9uaqZcn3E1fyYZ2M"
 user = "6ghLBF2LZAooDnmUMVm8tdNK6jhcAQhtbQiC7TgVnQ2r"
 
+if evm_loader is None:
+    print("Please set EVM_LOADER environment")
+    exit(1)
 
+if owner_contract is None:
+    print("Please set CONTRACT environment")
+    exit(1)
 
 def confirm_transaction(client, tx_sig):
     """Confirm a transaction."""
@@ -64,6 +71,16 @@ class EvmLoaderTests(unittest.TestCase):
             TransactionInstruction(program_id=evm_loader, data=data, keys=[
                 AccountMeta(pubkey=owner_contract, is_signer=False, is_writable=True),
                 AccountMeta(pubkey="6ghLBF2LZAooDnmUMVm8tdNK6jhcAQhtbQiC7TgVnQ2r", is_signer=False, is_writable=False),
+            ]))
+        result = http_client.send_transaction(trx, self.acc)
+
+
+    def test_call(self):
+        #data = bytearray.fromhex("893d20e8")
+        data = (1024*1024-1024).to_bytes(4, "little")
+        trx = Transaction().add(
+            TransactionInstruction(program_id=owner_contract, data=data, keys=[
+                AccountMeta(pubkey=owner_contract, is_signer=False, is_writable=True),
             ]))
         result = http_client.send_transaction(trx, self.acc)
 


### PR DESCRIPTION
This changes increase heap size for contract.

It's need patched solana-validator program to use this program. For v1.4.13 you can use next patch:
```
diff --git a/programs/bpf_loader/src/syscalls.rs b/programs/bpf_loader/src/syscalls.rs
index 21aa97f3f..0eef15872 100644
--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -89,7 +89,7 @@ use crate::allocator_bump::BPFAllocator;
 
 /// Default program heap size, allocators
 /// are expected to enforce this
-const DEFAULT_HEAP_SIZE: usize = 32 * 1024;
+const DEFAULT_HEAP_SIZE: usize = 1024 * 1024;
 
 pub fn register_syscalls<'a>(
     loader_id: &'a Pubkey,
diff --git a/sdk/src/process_instruction.rs b/sdk/src/process_instruction.rs
index 6c65c285d..fb792f656 100644
--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -100,7 +100,7 @@ impl BpfComputeBudget {
         let mut bpf_compute_budget =
         // Original
         BpfComputeBudget {
-            max_units: 100_000,
+            max_units: 10_000_000,
             log_units: 0,
             log_64_units: 0,
             create_program_address_units: 0,
@@ -115,7 +115,7 @@ impl BpfComputeBudget {
 
         if feature_set.is_active(&bpf_compute_budget_balancing::id()) {
             bpf_compute_budget = BpfComputeBudget {
-                max_units: 200_000,
+                max_units: 20_000_000,
                 log_units: 100,
                 log_64_units: 100,
                 create_program_address_units: 1500,
```