### PR TITLE
Account data realisation in enum

### DIFF
--- a/evm_loader/emulator/src/account_storage.rs
+++ b/evm_loader/emulator/src/account_storage.rs
@@ -282,7 +282,7 @@ impl AccountStorage for EmulatorAccountStorage {
                         Err(_) => return d(),
                     };
                     let code_data: std::rc::Rc<std::cell::RefCell<&mut [u8]>> = Rc::new(RefCell::new(&mut code_data));
-                    let account = SolidityAccount::new(&acc.key, acc.account.lamports, account_data, Some((contract_data.code_size, code_data))).unwrap();
+                    let account = SolidityAccount::new(&acc.key, acc.account.lamports, account_data, Some((contract_data, code_data))).unwrap();
                     f(&account)
                 } else {
                     let account = SolidityAccount::new(&acc.key, acc.account.lamports, account_data, None).unwrap();

--- a/evm_loader/emulator/src/account_storage.rs
+++ b/evm_loader/emulator/src/account_storage.rs
@@ -267,7 +267,7 @@ impl AccountStorage for EmulatorAccountStorage {
             Some(acc) => {
                 let account_data = match AccountData::unpack(&acc.account.data) {
                     Ok(acc_data) => match acc_data {
-                        AccountData::Account(acc) => acc,
+                        AccountData::Account(_) => acc_data,
                         _ => return d(),
                     },
                     Err(_) => return d(),
@@ -276,7 +276,7 @@ impl AccountStorage for EmulatorAccountStorage {
                     let mut code_data = acc.code_account.as_ref().unwrap().data.clone();
                     let contract_data = match AccountData::unpack(&code_data) {
                         Ok(acc_data) => match acc_data {
-                            AccountData::Contract(acc) => acc,
+                            AccountData::Contract(_) => acc_data,
                             _ => return d(),
                         },
                         Err(_) => return d(),

--- a/evm_loader/program/src/account_data.rs
+++ b/evm_loader/program/src/account_data.rs
@@ -6,7 +6,7 @@ use solana_program::{
 };
 
 #[derive(Debug,Clone)]
-pub struct AccountData {
+pub struct Account {
     pub ether: H160,
     pub nonce: u8,
     pub trx_count: u64,
@@ -15,108 +15,120 @@ pub struct AccountData {
 }
 
 #[derive(Debug,Clone)]
-pub struct ContractData {
+pub struct Contract {
     pub owner: Pubkey,
     pub code_size: u32,
 }
 
 #[derive(Debug,Clone)]
-pub enum AccountType {
-    AccountData(AccountData),
-    ContractData(ContractData),
+pub enum AccountData {
+    Account(Account),
+    Contract(Contract),
     Empty
 }
 
-impl AccountType {
-    pub const EMPTY_TAG: u8 = 0;
+impl AccountData {
+    const EMPTY_TAG: u8 = 0;
+    const ACCOUNT_TAG: u8 = 1;
+    const CONTRACT_TAG: u8 = 2;
 
     pub fn unpack(input: &[u8]) -> Result<Self, ProgramError> {
         let (&tag, rest) = input.split_first().ok_or(ProgramError::InvalidAccountData)?;
         Ok(match tag {
-            AccountType::EMPTY_TAG => AccountType::Empty,
-            AccountData::TAG => AccountType::AccountData( AccountData::unpack(rest)? ),
-            ContractData::TAG => AccountType::ContractData( ContractData::unpack(rest)? ),
+            AccountData::EMPTY_TAG => AccountData::Empty,
+            AccountData::ACCOUNT_TAG => AccountData::Account( Account::unpack(rest) ),
+            AccountData::CONTRACT_TAG => AccountData::Contract( Contract::unpack(rest) ),
 
             _ => return Err(ProgramError::InvalidAccountData),
         })
     }
-}
-
-impl AccountData {
-    pub const TAG: u8 = 1;
-    pub const HEADER_SIZE: usize = 20+1+8+32+32;
-    pub const SIZE: usize = 1 + AccountData::HEADER_SIZE;
-
-    pub fn unpack(input: &[u8]) -> Result<Self, ProgramError> {
-        if input.len() < AccountData::HEADER_SIZE {
-            return Err(ProgramError::InvalidAccountData);
-        }
-        let data = array_ref![input, 0, AccountData::HEADER_SIZE];
-        let (ether, nonce, trx_count, signer, code_account) = array_refs![data, 20, 1, 8, 32, 32];
-        
-        Ok(
-            AccountData {
-                ether: H160::from_slice(&*ether),
-                nonce: nonce[0],
-                trx_count: u64::from_le_bytes(*trx_count),
-                signer: Pubkey::new_from_array(*signer),
-                code_account: Pubkey::new_from_array(*code_account),
-            }
-        )
-    }
 
     pub fn pack(&self, dst: &mut [u8]) -> Result<usize, ProgramError> {
-        if dst.len() < AccountData::SIZE {
-            return Err(ProgramError::AccountDataTooSmall);
+        if dst.len() < 1 { return Err(ProgramError::AccountDataTooSmall); }
+        Ok(match self {
+            AccountData::Empty => 1,
+            AccountData::Account(acc) => {
+                if dst[0] != AccountData::ACCOUNT_TAG && dst[0] != AccountData::EMPTY_TAG { return Err(ProgramError::InvalidAccountData); }
+                if dst.len() < self.size() { return Err(ProgramError::AccountDataTooSmall); }
+                dst[0] = AccountData::ACCOUNT_TAG;
+                Account::pack(acc, &mut dst[1..])
+            },
+            AccountData::Contract(acc) => {
+                if dst[0] != AccountData::CONTRACT_TAG && dst[0] != AccountData::EMPTY_TAG { return Err(ProgramError::InvalidAccountData); }
+                if dst.len() < self.size() { return Err(ProgramError::AccountDataTooSmall); }
+                dst[0] = AccountData::CONTRACT_TAG;
+                Contract::pack(acc, &mut dst[1..])
+            },
+
+            _ => return Err(ProgramError::InvalidAccountData),
+        })
+    }
+
+    pub fn size(&self) -> usize {
+        match self {
+            AccountData::Account(acc) => acc.size() + 1,
+            AccountData::Contract(acc) => acc.size() + 1,
+            _ => return 1,
         }
-        if dst[0] != AccountType::EMPTY_TAG && dst[0] != AccountData::TAG {
-            return Err(ProgramError::InvalidAccountData);
+    }
+}
+
+impl Account {
+    pub const SIZE: usize = 20+1+8+32+32;
+
+    pub fn unpack(input: &[u8]) -> Self {
+        let data = array_ref![input, 0, Account::SIZE];
+        let (ether, nonce, trx_count, signer, code_account) = array_refs![data, 20, 1, 8, 32, 32];
+
+        Account {
+            ether: H160::from_slice(&*ether),
+            nonce: nonce[0],
+            trx_count: u64::from_le_bytes(*trx_count),
+            signer: Pubkey::new_from_array(*signer),
+            code_account: Pubkey::new_from_array(*code_account),
         }
-        dst[0] = AccountData::TAG;
-        let data = array_mut_ref![dst, 1, AccountData::HEADER_SIZE];
+    }
+
+    pub fn pack(acc: &Account, dst: &mut [u8]) -> usize {
+        let data = array_mut_ref![dst, 0, Account::SIZE];
         let (ether_dst, nonce_dst, trx_count_dst, signer_dst, code_account_dst) = 
                 mut_array_refs![data, 20, 1, 8, 32, 32];
-        *ether_dst = self.ether.to_fixed_bytes();
-        nonce_dst[0] = self.nonce;
-        *trx_count_dst = self.trx_count.to_le_bytes();
-        signer_dst.copy_from_slice(self.signer.as_ref());
-        code_account_dst.copy_from_slice(self.code_account.as_ref());
-        Ok(AccountData::HEADER_SIZE)
+        *ether_dst = acc.ether.to_fixed_bytes();
+        nonce_dst[0] = acc.nonce;
+        *trx_count_dst = acc.trx_count.to_le_bytes();
+        signer_dst.copy_from_slice(acc.signer.as_ref());
+        code_account_dst.copy_from_slice(acc.code_account.as_ref());
+        Account::SIZE
+    }
+
+    pub fn size(&self) -> usize {
+        Account::SIZE
     }
 }
 
-impl ContractData {
-    pub const TAG: u8 = 2;
-    pub const HEADER_SIZE: usize = 32+4;
-    pub const SIZE: usize = 1 + ContractData::HEADER_SIZE;
+impl Contract {
+    const SIZE: usize = 32+4;
 
-    pub fn unpack(input: &[u8]) -> Result<Self, ProgramError> {
-        if input.len() < ContractData::HEADER_SIZE {
-            return Err(ProgramError::InvalidAccountData);
-        }
-        let data = array_ref![input, 0, ContractData::HEADER_SIZE];
+    pub fn unpack(input: &[u8]) -> Self {
+        let data = array_ref![input, 0, Contract::SIZE];
         let (owner, code_size) = array_refs![data, 32, 4];
-        Ok(
-            ContractData {
-                owner: Pubkey::new_from_array(*owner),
-                code_size: u32::from_le_bytes(*code_size),
-            }
-        )
+
+        Contract {
+            owner: Pubkey::new_from_array(*owner),
+            code_size: u32::from_le_bytes(*code_size),
+        }
     }
 
-    pub fn pack(&self, dst: &mut [u8]) -> Result<usize, ProgramError> {
-        if dst.len() < ContractData::SIZE {
-            return Err(ProgramError::AccountDataTooSmall);
-        }
-        if dst[0] != AccountType::EMPTY_TAG && dst[0] != ContractData::TAG {
-            return Err(ProgramError::InvalidAccountData);
-        }
-        dst[0] = ContractData::TAG;
-        let data = array_mut_ref![dst, 1, ContractData::HEADER_SIZE];
+    pub fn pack(acc: &Contract, dst: &mut [u8]) -> usize {
+        let data = array_mut_ref![dst, 0, Contract::SIZE];
         let (owner_dst, code_size_dst) = 
                 mut_array_refs![data, 32, 4];
-                owner_dst.copy_from_slice(self.owner.as_ref());
-        *code_size_dst = self.code_size.to_le_bytes();
-        Ok(ContractData::HEADER_SIZE)
+        owner_dst.copy_from_slice(acc.owner.as_ref());
+        *code_size_dst = acc.code_size.to_le_bytes();
+        Contract::SIZE
+    }
+
+    pub fn size(&self) -> usize {
+        Contract::SIZE
     }
 }

--- a/evm_loader/program/src/account_data.rs
+++ b/evm_loader/program/src/account_data.rs
@@ -74,7 +74,7 @@ impl AccountData {
 }
 
 impl Account {
-    pub const SIZE: usize = 20+1+8+32+32;
+    const SIZE: usize = 20+1+8+32+32;
 
     pub fn unpack(input: &[u8]) -> Self {
         let data = array_ref![input, 0, Account::SIZE];

--- a/evm_loader/program/src/account_data.rs
+++ b/evm_loader/program/src/account_data.rs
@@ -71,6 +71,34 @@ impl AccountData {
             _ => return 1,
         }
     }
+
+    pub fn get_account(&self) -> Result<&Account, ProgramError>  {
+        match self {
+            AccountData::Account(ref acc) => Ok(acc),
+            _ => return Err(ProgramError::InvalidAccountData),
+        }
+    }
+
+    pub fn get_mut_account(&mut self) -> Result<&mut Account, ProgramError>  {
+        match self {
+            AccountData::Account(ref mut acc) => Ok(acc),
+            _ => return Err(ProgramError::InvalidAccountData),
+        }
+    }
+
+    pub fn get_contract(&self) -> Result<&Contract, ProgramError>  {
+        match self {
+            AccountData::Contract(ref acc) => Ok(acc),
+            _ => return Err(ProgramError::InvalidAccountData),
+        }
+    }
+
+    pub fn get_mut_contract(&mut self) -> Result<&mut Contract, ProgramError>  {
+        match self {
+            AccountData::Contract(ref mut acc) => Ok(acc),
+            _ => return Err(ProgramError::InvalidAccountData),
+        }
+    }
 }
 
 impl Account {

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -444,18 +444,17 @@ fn do_write(account_info: &AccountInfo, offset: u32, bytes: &[u8]) -> ProgramRes
     let mut data = account_info.data.borrow_mut();
 
     let account_data = AccountData::unpack(&data)?;
-    let header_size: usize = match account_data {
+    match account_data {
         AccountData::Contract(ref acc) => {
             if acc.code_size != 0 {
                 return Err(ProgramError::InvalidAccountData);
             }
-            account_data.size()
         },
         AccountData::Account(_) => return Err(ProgramError::InvalidAccountData),
-        AccountData::Empty => account_data.size(),
+        AccountData::Empty => (),
     };
 
-    let offset = header_size + offset as usize;
+    let offset = account_data.size() + offset as usize;
     if data.len() < offset + bytes.len() {
         debug_print!("Account data too small");
         return Err(ProgramError::AccountDataTooSmall);

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -155,8 +155,9 @@ fn process_instruction<'a>(
 
             //debug_print!(&("Ether:".to_owned()+&(hex::encode(ether))+" "+&hex::encode([nonce])));
             if base_info.owner != program_id {return Err(ProgramError::InvalidArgument);}
-            let base_info_data = match AccountData::unpack(&base_info.data.borrow())? {
-                AccountData::Account(acc) => acc,
+            let base_info_data = AccountData::unpack(&base_info.data.borrow())?;
+            match base_info_data {
+                AccountData::Account(_) => (),
                 _ => return Err(ProgramError::InvalidAccountData),
             };
             let caller = SolidityAccount::new(base_info.key, (*base_info.lamports.borrow()).clone(), base_info_data, None)?;

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -492,7 +492,7 @@ fn do_finalize<'a>(program_id: &Pubkey, accounts: &'a [AccountInfo<'a>]) -> Prog
             let data = program_code.data.borrow();
             let contract_info_data = AccountData::unpack(&data)?;
             match contract_info_data {
-                AccountData::Empty => (),
+                AccountData::Contract (..) => (),
                 _ => return Err(ProgramError::InvalidAccountData),
             };
 

--- a/evm_loader/program/src/solidity_account.rs
+++ b/evm_loader/program/src/solidity_account.rs
@@ -17,23 +17,23 @@ use std::convert::TryInto;
 
 #[derive(Debug, Clone)]
 pub struct SolidityAccount<'a> {
-    account_data: Account,
+    account_data: AccountData,
     solana_address: &'a Pubkey,
-    code_data: Option<(Contract, Rc<RefCell<&'a mut [u8]>>)>,
+    code_data: Option<(AccountData, Rc<RefCell<&'a mut [u8]>>)>,
     lamports: u64,
 }
 
 impl<'a> SolidityAccount<'a> {
-    pub fn new(solana_address: &'a Pubkey, lamports: u64, account_data: Account, code_data: Option<(Contract, Rc<RefCell<&'a mut [u8]>>)>) -> Result<Self, ProgramError> {
+    pub fn new(solana_address: &'a Pubkey, lamports: u64, account_data: AccountData, code_data: Option<(AccountData, Rc<RefCell<&'a mut [u8]>>)>) -> Result<Self, ProgramError> {
         debug_print!("  SolidityAccount::new");
         Ok(Self{account_data, solana_address, code_data, lamports})
     }
 
-    pub fn get_signer(&self) -> Pubkey {self.account_data.signer}
+    pub fn get_signer(&self) -> Pubkey {AccountData::get_account(&self.account_data).unwrap().signer}
 
-    pub fn get_ether(&self) -> H160 {self.account_data.ether}
+    pub fn get_ether(&self) -> H160 {AccountData::get_account(&self.account_data).unwrap().ether}
 
-    pub fn get_nonce(&self) -> u64 {self.account_data.trx_count}
+    pub fn get_nonce(&self) -> u64 {AccountData::get_account(&self.account_data).unwrap().trx_count}
 
     fn code<U, F>(&self, f: F) -> U
     where F: FnOnce(&[u8]) -> U {
@@ -49,8 +49,8 @@ impl<'a> SolidityAccount<'a> {
         }
 
         let contract_data = &self.code_data.as_ref().unwrap().0;
-        let code_size = contract_data.code_size as usize;
-        let contract_data = AccountData::Contract(contract_data.clone());
+        let contract = AccountData::get_contract(&contract_data).unwrap();
+        let code_size = contract.code_size as usize;
 
         if code_size > 0 {
             let data = self.code_data.as_ref().unwrap().1.borrow();
@@ -77,8 +77,8 @@ impl<'a> SolidityAccount<'a> {
         }
 
         let contract_data = &self.code_data.as_ref().unwrap().0;
-        let code_size = contract_data.code_size as usize;
-        let contract_data = AccountData::Contract(contract_data.clone());
+        let contract = AccountData::get_contract(&contract_data)?;
+        let code_size = contract.code_size as usize;
 
         if code_size > 0 {
             let mut data = self.code_data.as_ref().unwrap().1.borrow_mut();
@@ -94,12 +94,12 @@ impl<'a> SolidityAccount<'a> {
         *self.solana_address
     }
 
-    pub fn get_seeds(&self) -> (H160, u8) { (self.account_data.ether, self.account_data.nonce) }
+    pub fn get_seeds(&self) -> (H160, u8) { (AccountData::get_account(&self.account_data).unwrap().ether, AccountData::get_account(&self.account_data).unwrap().nonce) }
     
     pub fn basic(&self) -> Basic {
         Basic { 
             balance: self.lamports.into(), 
-            nonce: U256::from(self.account_data.trx_count), }
+            nonce: U256::from(AccountData::get_account(&self.account_data).unwrap().trx_count), }
         
     }
     
@@ -145,62 +145,58 @@ impl<'a> SolidityAccount<'a> {
             AccountData::Foreign => 0,
             AccountData::Account{code_size, ..} => code_size as usize,
         };*/
-        self.account_data.trx_count = nonce.as_u64();
-
-        let mut code_size = match &self.code_data {
-            Some((acc, _code)) => acc.code_size,
-            _ => 0,
-        };
+        AccountData::get_mut_account(&mut self.account_data)?.trx_count = nonce.as_u64();
 
         if let Some(code) = code {
             debug_print!("Write contract");
-            if self.code_data.is_none() {
-                debug_print!("Expected code account");
-                return Err(ProgramError::NotEnoughAccountKeys);
-            };
-
-            let mut code_data = self.code_data.as_ref().unwrap().1.borrow_mut();
-            let mut contract_data = self.code_data.as_ref().unwrap().0.clone();
-
-            if contract_data.code_size != 0 {
-                return Err(ProgramError::AccountAlreadyInitialized);
-            };
-
-            contract_data.code_size = code.len().try_into().map_err(|_| ProgramError::AccountDataTooSmall)?;
-            code_size = contract_data.code_size;
-
-            debug_print!("Write contract header");
-            let contract_data = AccountData::Contract(contract_data);
-            contract_data.pack(&mut code_data)?;
-            debug_print!("Write code");
-            code_data[contract_data.size()..contract_data.size()+code.len()].copy_from_slice(&code);
-            debug_print!("Code written");
+            match self.code_data {
+                Some((ref mut contract_data, ref mut code_data)) => {
+                    let mut code_data = code_data.borrow_mut();
+                    let contract = AccountData::get_mut_contract(contract_data)?;
+        
+                    if contract.code_size != 0 {
+                        return Err(ProgramError::AccountAlreadyInitialized);
+                    };
+                    contract.code_size = code.len().try_into().map_err(|_| ProgramError::AccountDataTooSmall)?;
+        
+                    debug_print!("Write contract header");
+                    contract_data.pack(&mut code_data)?;
+                    debug_print!("Write code");
+                    code_data[contract_data.size()..contract_data.size()+code.len()].copy_from_slice(&code);
+                    debug_print!("Code written");
+                },
+                None => {
+                    debug_print!("Expected code account");
+                    return Err(ProgramError::NotEnoughAccountKeys);
+                }
+            }
         }
 
         debug_print!("Write account data");        
-        let account_data = AccountData::Account(self.account_data.clone()); 
-        account_data.pack(&mut data)?;
+        self.account_data.pack(&mut data)?;
 
         let mut storage_iter = storage_items.into_iter().peekable();
         let exist_items = if let Some(_) = storage_iter.peek() {true} else {false};
         if reset_storage || exist_items {
             debug_print!("Update storage");
-            if self.code_data.is_none() {
-                debug_print!("Expected code account");
-                return Err(ProgramError::NotEnoughAccountKeys);
-            };
-
-            let mut code_data = self.code_data.as_ref().unwrap().1.borrow_mut();
-            let contract_data = &self.code_data.as_ref().unwrap().0;
-
-            if code_size == 0 {return Err(ProgramError::UninitializedAccount);};
-
-            let contract_data = AccountData::Contract(contract_data.clone());
-            let mut storage = Hamt::new(&mut code_data[contract_data.size()+(code_size as usize)..], reset_storage)?;
-            debug_print!("Storage initialized");
-            for (key, value) in storage_iter {
-                debug_print!("Storage value: {} = {}", &key.to_string(), &value.to_string());
-                storage.insert(key.as_fixed_bytes().into(), value.as_fixed_bytes().into())?;
+            match self.code_data {
+                Some((ref contract_data, ref mut code_data)) => {
+                    let mut code_data = code_data.borrow_mut();
+        
+                    let contract = AccountData::get_contract(&contract_data)?;
+                    if contract.code_size == 0 {return Err(ProgramError::UninitializedAccount);};
+        
+                    let mut storage = Hamt::new(&mut code_data[contract_data.size()+(contract.code_size as usize)..], reset_storage)?;
+                    debug_print!("Storage initialized");
+                    for (key, value) in storage_iter {
+                        debug_print!("Storage value: {} = {}", &key.to_string(), &value.to_string());
+                        storage.insert(key.as_fixed_bytes().into(), value.as_fixed_bytes().into())?;
+                    }
+                },
+                None => {
+                    debug_print!("Expected code account");
+                    return Err(ProgramError::NotEnoughAccountKeys);
+                }
             }
         }
 


### PR DESCRIPTION
Move checks and pack and size methods from Account and Contract to AccountData.
Hide account data constants behind functions.
