### PR TITLE
Speedup CI by disabling configuration with logs #157

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,7 @@ FROM builder AS evm-loader-builder
 COPY ./evm_loader/ /opt/evm_loader/
 WORKDIR /opt/evm_loader/program
 RUN cargo build-bpf
-RUN cd ../emulator && cargo build --release
-# Build evm_loader_no_logs
-RUN sed -i 's/\(name = \)"evm-loader"/\1"evm-loader-no-logs"/' Cargo.toml && \
-    cargo build-bpf --no-default-features --features custom-heap
+RUN cd ../emulator && cargo build --release --features no-logs
 
 # Build Solidity contracts
 FROM ethereum/solc:0.5.12 AS solc
@@ -62,7 +59,7 @@ COPY --from=solana /opt/solana/bin/solana /opt/solana/bin/solana-keygen /opt/sol
 COPY --from=solana-deploy /opt/solana/bin/solana /opt/solana/bin/solana-deploy
 
 COPY --from=spl-memo-builder /opt/memo/program/target/deploy/spl_memo.so /opt/
-COPY --from=evm-loader-builder /opt/evm_loader/program/target/deploy/evm_loader.so /opt/evm_loader/program/target/deploy/evm_loader_no_logs.so /opt/
+COPY --from=evm-loader-builder /opt/evm_loader/program/target/deploy/evm_loader.so /opt/
 COPY --from=evm-loader-builder /opt/evm_loader/emulator/target/release/emulator /opt/
 COPY --from=token-cli-builder /opt/token/cli/target/release/spl-token /opt/solana/bin/
 COPY --from=contracts /opt/ /opt/solidity/

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN cd /opt/memo/program && cargo build-bpf
 FROM builder AS evm-loader-builder
 COPY ./evm_loader/ /opt/evm_loader/
 WORKDIR /opt/evm_loader/program
-RUN cargo build-bpf
-RUN cd ../emulator && cargo build --release --features no-logs
+RUN cargo build-bpf --features no-logs
+RUN cd ../emulator && cargo build --release
 
 # Build Solidity contracts
 FROM ethereum/solc:0.5.12 AS solc

--- a/evm_loader/deploy-test.sh
+++ b/evm_loader/deploy-test.sh
@@ -14,12 +14,8 @@ done
 solana airdrop 1000
 solana account $ACCOUNT
 
-echo "Run tests with EVM Loader logs"
+echo "Run tests for EVM Loader"
 export EVM_LOADER=$(solana-deploy deploy evm_loader.so | tail -n 1 | python3 -c 'import sys, json; data=json.load(sys.stdin); print(data["programId"]);')
-python3 -m unittest discover -v -p 'test*.py'
-
-echo "Run tests without EVM Loader logs"
-export EVM_LOADER=$(solana-deploy deploy evm_loader_no_logs.so | tail -n 1 | python3 -c 'import sys, json; data=json.load(sys.stdin); print(data["programId"]);')
 python3 -m unittest discover -v -p 'test*.py'
 
 echo "Deploy test success"

--- a/evm_loader/program/Cargo.toml
+++ b/evm_loader/program/Cargo.toml
@@ -12,11 +12,11 @@ edition = "2018"
 exclude = ["js/**"]
 
 [features]
-evm_debug = []
+no-logs = []
 no-entrypoint = []
 test-bpf = []
 custom-heap = []
-default = ["custom-heap", "evm_debug"]
+default = ["custom-heap"]
 
 [dependencies]
 solana-program = { version = "1.6.4", default_features = false }

--- a/evm_loader/program/src/debug.rs
+++ b/evm_loader/program/src/debug.rs
@@ -1,15 +1,15 @@
 
-#[cfg(all(target_arch = "bpf", feature = "evm_debug"))]
+#[cfg(all(target_arch = "bpf", not(feature = "no-logs")))]
 macro_rules! debug_print {
     ($( $args:expr ),*) => { solana_program::msg!( $( $args ),* ) }
 }
 
-#[cfg(all(not(target_arch = "bpf"), feature = "evm_debug"))]
+#[cfg(all(not(target_arch = "bpf"), not(feature = "no-logs")))]
 macro_rules! debug_print {
     ($( $args:expr ),*) => { eprintln!( $( $args ),* ) }
 }
 
-#[cfg(not(feature = "evm_debug"))]
+#[cfg(feature = "no-logs")]
 macro_rules! debug_print {
     ($( $args:expr ),*) => {}
 }

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -689,8 +689,8 @@ fn do_partial_call<'a>(
 
     debug_print!("Executor initialized");
 
-    debug_print!(&("   caller: ".to_owned() + &caller_ether.0.to_string()));
-    debug_print!(&(" contract: ".to_owned() + &contract_ether.to_string()));
+    debug_print!("   caller: {}", &caller_ether.0.to_string());
+    debug_print!(" contract: {}", &contract_ether.to_string());
 
     executor.call_begin(caller_ether.0, contract_ether, instruction_data, u64::max_value());
     executor.execute_n_steps(step_count).unwrap();

--- a/evm_loader/program/src/transaction.rs
+++ b/evm_loader/program/src/transaction.rs
@@ -60,8 +60,8 @@ pub fn check_secp256k1_instruction(sysvar_info: &AccountInfo, message_len: usize
                 let reference_instruction = make_secp256k1_instruction(current_instruction, message_len, data_offset);
                 if reference_instruction != instr.data {
                     debug_print!("wrong keccak instruction data");
-                    debug_print!(&("instruction: ".to_owned() + &hex::encode(&instr.data)));    
-                    debug_print!(&("reference: ".to_owned() + &hex::encode(&reference_instruction)));    
+                    debug_print!("instruction: {}", &hex::encode(&instr.data));
+                    debug_print!("reference: {}", &hex::encode(&reference_instruction));
                     return Err(ProgramError::InvalidInstructionData);
                 }
             } else {


### PR DESCRIPTION
Speedup CI by disabling run configuration with logs.
Regular builds produce evm_loader with logs, so developers can build, deploy and debug as usual.
evm_loader with logs can be produced by `cargo build-bpf --features no-logs`.
Build without logs was chosen for CI so that errors would appear if a code with logic gets into the log output code.