### PR TITLE
Account data print in neon-cli #174

### DIFF
--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -517,9 +517,6 @@ fn command_deploy(
         )?;
     }
 
-    println!("Account created");
-    command_get_ether_account_data(&config, &ether);
-
     {  // Send write message
         let (blockhash, _, last_valid_slot) = config.rpc_client
             .get_recent_blockhash_with_commitment(config.rpc_client.commitment())?
@@ -565,9 +562,6 @@ fn command_deploy(
                 format!("Finalizing program account failed: {}", e)
             })?;
     }
-
-    println!("Contract finalized created");
-    command_get_ether_account_data(&config, &ether);
 
     println!("{}", json!({
         "programId": format!("{}", program_id),


### PR DESCRIPTION
Add subcommand "get-ether-account-data" to neon-cli to show parsed ethereum account data stored in solana.
Extract function of getting account data from solana from EmulatorAccountStorage to reuse it in get-ether-account-data command.