### PR TITLE
Print information about deployed contract in emulator #164

### DIFF
--- a/evm_loader/cli/src/account_storage.rs
+++ b/evm_loader/cli/src/account_storage.rs
@@ -26,6 +26,7 @@ struct AccountJSON {
     contract: Option<String>,
     writable: bool,
     new: bool,
+    code_size: Option<usize>,
 }
 
 struct SolanaAccount {
@@ -33,18 +34,31 @@ struct SolanaAccount {
     code_account: Option<Account>,
     key: Pubkey,
     writable: bool,
+    code_size: Option<usize>,
+}
+
+struct SolanaNewAccount {
+    key: Pubkey,
+    writable: bool,
+    code_size: Option<usize>
 }
 
 impl SolanaAccount {
-    pub fn new(account: Account, key: Pubkey, code_account: Option<Account>,) -> SolanaAccount {
+    pub fn new(account: Account, key: Pubkey, code_account: Option<Account>) -> SolanaAccount {
         eprintln!("SolanaAccount::new");
-        Self{account, key, writable: false, code_account}
+        Self{account, key, writable: false, code_account, code_size: None}
+    }
+}
+
+impl SolanaNewAccount {
+    pub fn new(key: Pubkey) -> SolanaNewAccount {
+        Self{key, writable: false, code_size: None}
     }
 }
 
 pub struct EmulatorAccountStorage<'a> {
     accounts: RefCell<HashMap<H160, SolanaAccount>>,
-    new_accounts: RefCell<HashSet<H160>>,
+    new_accounts: RefCell<HashMap<H160, SolanaNewAccount>>,
     config: &'a Config,
     contract_id: H160,
     caller_id: H160,
@@ -82,7 +96,7 @@ impl<'a> EmulatorAccountStorage<'a> {
 
         Self {
             accounts: RefCell::new(HashMap::new()),
-            new_accounts: RefCell::new(HashSet::new()),
+            new_accounts: RefCell::new(HashMap::new()),
             config: config,
             contract_id: contract_id,
             caller_id: caller_id,
@@ -140,7 +154,7 @@ impl<'a> EmulatorAccountStorage<'a> {
                 None => {
                     eprintln!("Account not found {}", &address.to_string());
 
-                    new_accounts.insert(address.clone());
+                    new_accounts.insert(address.clone(), SolanaNewAccount::new(solana_address));
 
                     false
                 }
@@ -162,17 +176,18 @@ impl<'a> EmulatorAccountStorage<'a> {
                 I: IntoIterator<Item=(H256, H256)>,
     {             
         let mut accounts = self.accounts.borrow_mut(); 
+        let mut new_accounts = self.new_accounts.borrow_mut();
 
         for apply in values {
             match apply {
-                Apply::Modify {address, basic, code: _, storage: _, reset_storage} => {
-                    match accounts.get_mut(&address) {
-                        Some(acc) => {
-                            *acc.writable.borrow_mut() = true;
-                        },
-                        None => {
-                            eprintln!("Account not found {}", &address.to_string());
-                        },
+                Apply::Modify {address, basic, code, storage: _, reset_storage} => {
+                    if let Some(acc) = accounts.get_mut(&address) {
+                        *acc.writable.borrow_mut() = true;
+                        *acc.code_size.borrow_mut() = code.map(|v| v.len());
+                    } else if let Some(acc) = new_accounts.get_mut(&address) {
+                        *acc.code_size.borrow_mut() = code.map(|v| v.len());
+                    } else {
+                        eprintln!("Account not found {}", &address.to_string());
                     }
                     eprintln!("Modify: {} {} {} {}", &address.to_string(), &basic.nonce.as_u64(), &basic.balance.as_u64(), &reset_storage.to_string());
                 },
@@ -205,12 +220,13 @@ impl<'a> EmulatorAccountStorage<'a> {
                     writable: acc.writable,
                     new: false,
                     account: solana_address.to_string(),
-                    contract: contract_address.map(|v| v.to_string())
+                    contract: contract_address.map(|v| v.to_string()),
+                    code_size: acc.code_size,
                 });
         }
 
         let new_accounts = self.new_accounts.borrow();
-        for address in new_accounts.iter() {
+        for (address, acc) in new_accounts.iter() {
             let solana_address = Pubkey::find_program_address(&[&address.to_fixed_bytes()], &self.config.evm_loader).0;
             arr.push(AccountJSON{
                     address: "0x".to_string() + &hex::encode(&address.to_fixed_bytes()),
@@ -218,6 +234,7 @@ impl<'a> EmulatorAccountStorage<'a> {
                     new: true,
                     account: solana_address.to_string(),
                     contract: None,
+                    code_size: acc.code_size,
                 });
         }    
 

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -655,6 +655,26 @@ fn main() {
                 .validator(is_valid_pubkey)
                 .help("Pubkey for evm_loader contract")
         )
+        .arg(
+            Arg::with_name("commitment")
+                .long("commitment")
+                .takes_value(true)
+                .possible_values(&[
+                    "processed",
+                    "confirmed",
+                    "finalized",
+                    "recent", // Deprecated as of v1.5.5
+                    "single", // Deprecated as of v1.5.5
+                    "singleGossip", // Deprecated as of v1.5.5
+                    "root", // Deprecated as of v1.5.5
+                    "max", // Deprecated as of v1.5.5
+                ])
+                .value_name("COMMITMENT_LEVEL")
+                .hide_possible_values(true)
+                .global(true)
+                .default_value("max")
+                .help("Return information at the selected commitment level [possible values: processed, confirmed, finalized]"),
+        )
         .subcommand(
             SubCommand::with_name("emulate")
                 .about("Emulate execution of Ethereum transaction")
@@ -756,6 +776,8 @@ fn main() {
                 solana_cli_config::Config::default()
             };
 
+            let commitment = CommitmentConfig::from_str(app_matches.value_of("commitment").unwrap()).unwrap();
+
             let json_rpc_url = normalize_to_url_if_moniker(
                 app_matches
                     .value_of("json_rpc_url")
@@ -786,7 +808,7 @@ fn main() {
             });
 
             Config {
-                rpc_client: RpcClient::new_with_commitment(json_rpc_url, CommitmentConfig::default()),
+                rpc_client: RpcClient::new_with_commitment(json_rpc_url, commitment),
                 evm_loader,
                 fee_payer,
                 signer,

--- a/evm_loader/program/src/debug.rs
+++ b/evm_loader/program/src/debug.rs
@@ -6,7 +6,7 @@ macro_rules! debug_print {
 
 #[cfg(all(not(target_arch = "bpf"), not(feature = "no-logs")))]
 macro_rules! debug_print {
-    ($( $args:expr ),*) => { logs::debug!( $( $args ),* ) }
+    ($( $args:expr ),*) => { eprintln!( $( $args ),* ) }
 }
 
 #[cfg(feature = "no-logs")]

--- a/evm_loader/program/src/solidity_account.rs
+++ b/evm_loader/program/src/solidity_account.rs
@@ -136,7 +136,7 @@ impl<'a> SolidityAccount<'a> {
     ) -> Result<(), ProgramError>
     where I: IntoIterator<Item = (H256, H256)> 
     {
-        println!("Update: {}, {}, {}, {:?} for {:?}", solidity_address, nonce, lamports, if let Some(_) = code {"Exist"} else {"Empty"}, self);
+        debug_print!("Update: {}, {}, {}, {:?}, {}", solidity_address, nonce, lamports, if let Some(_) = code {"Exist"} else {"Empty"}, reset_storage);
         let mut data = (*account_info.data).borrow_mut();
         **(*account_info.lamports).borrow_mut() = lamports;
 


### PR DESCRIPTION
Print information about the size of the deployed contract in the emulator. It looks like this:
```
{
   "accounts": [
      ...
      {
         "account": "RKxkCdRec87X3s56V3wenbj48WyNWxkoJrK8r6q2f1n",
         "address": "0x39918e16309714233253dc65f12573d9f6794549",
         "code_size": 11293,
         "contract": null,
         "new": true,
         "writable": true
      }
   ],
   "exit_status": "succeed",
   "result": "00000000000000000000000039918e16309714233253dc65f12573d9f6794549"
}
```