### PR TITLE
Fix CI build (back to solana-py version 0.6.5) #192

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install openssl ca-certificates curl python3 python3-pip && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install solana web3 pysha3
+RUN pip3 install solana==0.6.5 web3 pysha3
 COPY solana-py.patch /tmp/
 RUN cd /usr/local/lib/python3.8/dist-packages/ && patch -p0 </tmp/solana-py.patch
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,8 +51,8 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install openssl ca-certificates curl python3 python3-pip && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install solana==0.6.5 web3 pysha3
-COPY solana-py.patch /tmp/
+COPY evm_loader/test_requirements.txt solana-py.patch /tmp/
+RUN pip3 install -r /tmp/test_requirements.txt
 RUN cd /usr/local/lib/python3.8/dist-packages/ && patch -p0 </tmp/solana-py.patch
 
 COPY --from=solana /opt/solana/bin/solana /opt/solana/bin/solana-keygen /opt/solana/bin/solana-faucet /opt/solana/bin/

--- a/evm_loader/test_requirements.txt
+++ b/evm_loader/test_requirements.txt
@@ -1,0 +1,7 @@
+typing-extensions==3.7.4.2
+ecdsa==0.16.0
+pysha3==1.0.2
+eth-keys==0.3.3
+rlp==2.0.1
+web3
+solana==0.6.5


### PR DESCRIPTION
In the new version of the Python Solana library (0.8.0) was changed names of InstructionType.
CreateAccountWithSeed -> CREATE_ACCOUNT_WITH_SEED.

This change fixes the used version to 0.6.5.
Support new version of the library will be done in #193 