### PR TITLE
Run proxy CI after build #196

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,9 +6,9 @@ steps:
 
   - wait
 
-#  - label: ":cop::skin-tone-2: deploy check"
-#    command: ".buildkite/steps/deploy-test.sh"
-#    timeout: 60
+  - label: ":cop::skin-tone-2: deploy check"
+    command: ".buildkite/steps/deploy-test.sh"
+    timeout: 60
 
   - label: ":docker: build proxy docker image"
     trigger: "neon-proxy"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,6 +10,13 @@ steps:
     command: ".buildkite/steps/deploy-test.sh"
     timeout: 60
 
+  - label: ":docker: build proxy docker image"
+    trigger: "neon-proxy"
+    build:
+       branch: ${PROXY_BRANCH:develop}
+       env:
+          EVM_LOADER_REVISION: "${BUILDKITE_COMMIT}"
+
   - wait
 
   - label: ":floppy_disk: publish image"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,7 +13,7 @@ steps:
   - label: ":docker: build proxy docker image"
     trigger: "neon-proxy"
     build:
-       branch: ${PROXY_BRANCH:develop}
+       branch: "${PROXY_BRANCH:-develop}"
        env:
           EVM_LOADER_REVISION: "${BUILDKITE_COMMIT}"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,9 +6,9 @@ steps:
 
   - wait
 
-  - label: ":cop::skin-tone-2: deploy check"
-    command: ".buildkite/steps/deploy-test.sh"
-    timeout: 60
+#  - label: ":cop::skin-tone-2: deploy check"
+#    command: ".buildkite/steps/deploy-test.sh"
+#    timeout: 60
 
   - label: ":docker: build proxy docker image"
     trigger: "neon-proxy"


### PR DESCRIPTION
Proxy CI runs automatically for `develop`-branch.
User can specify proxy-branch with custom build using `PROXY_BRANCH="<some-proxy-brunch>"`